### PR TITLE
Fix: Ubuntu 24 high CPU load

### DIFF
--- a/src/slam/arise_slam_mid360/src/LaserMapping/laserMapping.cpp
+++ b/src/slam/arise_slam_mid360/src/LaserMapping/laserMapping.cpp
@@ -1121,7 +1121,7 @@ namespace arise_slam {
     }
 
     void laserMapping::process() {
-        while (rclcpp::ok()) {
+        if (rclcpp::ok()) {
             while (!cornerLastBuf.empty() && !surfLastBuf.empty() &&
                    !fullResBuf.empty()&& !IMUPredictionBuf.empty() ) {
 
@@ -1288,8 +1288,8 @@ namespace arise_slam {
                 //     saveLocalizationPose(timeLaserOdometry, T_w_lidar, slam.map_dir.c_str());
                 // save_debug_statistic(debug_file);
             }
-            std::chrono::milliseconds dura(2);
-            std::this_thread::sleep_for(dura);
+            // std::chrono::milliseconds dura(2);
+            // std::this_thread::sleep_for(dura);
         }
     }
 


### PR DESCRIPTION
```create_wall_timer()``` will call ```laserMapping::process()``` every 100ms. 

Current implementation of
```c++
while (rclcpp::ok()) {

  // clear buffer

  std::chrono::milliseconds dura(2);
  std::this_thread::sleep_for(dura);
}
```
inside ```process()``` will create an infinite while loop everytime ```process()``` is called.

Checking roscore status with ```if (rclcpp::ok()) {}``` should be sufficient.